### PR TITLE
Comment on PR if CLA is not signed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: cla-check
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   cla-check:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 This GitHub Action verifies whether or not the authors of a pull request have signed the Canonical Contributor Licence Agreement (https://ubuntu.com/legal/contributors).
 
+It will comment on the PR if any authors have not signed the CLA and update the messages when new commits or run are processed.
+
 ## Inputs
 
 ### `accept-existing-contributors`
 
 **Optional** Pass CLA check for existing project contributors (default: false)
+**Optional** Choose which GitHub access token (e.g. secrets.GITHUB_TOKEN) is used to create or update the comment CLA and check for existing project contributors (default: {{ github.token }})
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Pass CLA check for existing project contributors'
     required: false
     default: false
+  GITHUB_TOKEN:
+    description: 'The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create or update the comment and check for existing project contributors. This defaults to {{ github.token }}.'
+    default: '${{ github.token }}'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
The action will now comment on PR directly if any authors has not signed
the CLA.
Any rerun (commit or manual) will update the existing comment and
add/remove to the list of non signers.
If everyone has signed the CLA, the existing comment will be updated
again for one last time.
Finally, no comment is posted in the PR if everyone has signed the CLA.