### PR TITLE
Give different message when CLA check fails due to unknown error

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ async function run() {
         commit_authors[i]['signed'] = false;
       }
     }).catch((error) => {
-      console.log('- ' + username + ' ✕ (has not signed the CLA)');
+      console.log('- ' + username + ' ✕ (issue checking CLA status [' + error + '])');
       commit_authors[i]['signed'] = false
     });
   }


### PR DESCRIPTION
Lately, I've been seeing multiple failures (with the GitHub username check) where it appears that the CLA check fails due to a generic error from the request.  Running the action multiple times seems to eventually result in a pass but I think we should really log these as a separate message in order to diagnose why they're failing (e.g. API rate limit).