### PR TITLE
feat: ignore noreply addresses

### DIFF
--- a/lp_cla_check.py
+++ b/lp_cla_check.py
@@ -7,6 +7,9 @@ from launchpadlib.launchpad import Launchpad
 
 def lp_email_check(email, lp, cla_members):
     user = lp.people.getByEmail(email=email)
+    if email.find('noreply')!=-1:
+        print('- ' + email + ' ✓ noreply address')
+        return True
     if not user:
         print('- ' + email + ' ✕ (has no Launchpad account)')
         return False


### PR DESCRIPTION
We currently have an issue with the action.
At some point we introduced a noreply address which makes it impossible to use to sign the CLA. (See https://github.com/ubuntu/app-center/pull/1598)
Rather than a mergeable pull request, this is also a question on how to deal with this situation.
If there is a better solution feel free to comment and close the pull request.