### PR TITLE
Add handling for when author is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,8 @@ async function run() {
     var username;
     if (commits.data[i]['author']) {
       username = commits.data[i]['author']['login'];
+    } else {
+      username = null;
     }
     const email = commits.data[i]['commit']['author']['email'];
     commit_authors[username] = {


### PR DESCRIPTION
There are some very specific conditions where a user who has not signed the CLA can still have their PR pass the cla-check workflow if they rebase, and push commits that were authored by someone who has signed the CLA, but their author information returns `null`.

https://github.com/wallentx/lightdm/pull/3
https://github.com/wallentx/lightdm/pull/3/commits

In the above example, the true contributor details are:
```json
[
    {
        "username": "wallentx",
        "email": "wallentx@users.noreply.github.com",
        "signed": false
    },
    {
        "username": null,
        "email": "guido+freiesoftware@berhoerster.name",
        "signed": false
    },
    {
        "username": "madpilot78",
        "email": "mad@madpilot.net",
        "signed": false
    },
    {
        "username": "n3rdopolis",
        "email": "bluescreenavenger@gmail.com",
        "signed": false
    }
]
```
But without handling of `null`, the list gets deformed, and is processed as:
```json
[
    {
        "username": "wallentx",
        "email": "guido+freiesoftware@berhoerster.name",
        "signed": false
    },
    {
        "username": "madpilot78",
        "email": "mad@madpilot.net",
        "signed": false
    },
    {
        "username": "n3rdopolis",
        "email": "bluescreenavenger@gmail.com",
        "signed": false
    }
]
```

And so during the CI run, you see:
```
Checking the following users on GitHub:
- wallentx ✕ (issue checking CLA status [HttpError: User does not exist or is not a public member of the organization])
- madpilot78 ✕ (issue checking CLA status [HttpError: User does not exist or is not a public member of the organization])
- n3rdopolis ✕ (issue checking CLA status [HttpError: User does not exist or is not a public member of the organization])

Checking the following users on Launchpad:
- guido+freiesoftware@berhoerster.name ✓ (has signed the CLA)
- mad@madpilot.net ✓ (has signed the CLA)
- bluescreenavenger@gmail.com ✓ (has signed the CLA)

CLA Check - PASSED
```
The GitHub API is unable to derive the GitHub username for `guido` (https://github.com/gber) from the query being used (I don't actually know if there's a GH API endpoint that will allow you to discover that if their commit can't be associated with a REF), so the `author` information shows up as `null`, which I guess the prior record ends up taking its place. my email address is never checked against Launchpad, because it slotted me down into the null spot.
This check should not have passed, because I have never signed the CLA.
https://github.com/wallentx/lightdm/actions/runs/8579267328/job/23514827215?pr=3