### PR TITLE
Remove `exempted-bots` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ When run on the `pull_request_target` event, this action will also comment on th
 
 **Optional** The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create a CLA comment on the pull request (default: {{ github.token }})
 
-### `exempted-bots`
-
-**Optional** A comma-separated list of GitHub bots to exempt from CLA requirements. (default: dependabot,renovate)
-
 ### `implicit-approval-from-licenses`
 
 **Optional** A comma-separated list of SPDX licenses identifiers (https://spdx.org/licenses/) for which approval of the CLA requirements is implicit. (default: Apache-2.0)

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create a CLA comment on the pull request (default: {{ github.token }}).'
     default: '${{ github.token }}'
     required: false
-  exempted-bots:
-    description: 'GitHub usernames for exempted bot accounts.'
-    default: 'dependabot,renovate'
-    required: false
   implicit-approval-from-licenses:
     description: 'Licences for which an implicit approval of the CLA is assumed.'
     default: 'Apache-2.0'

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const github = require('@actions/github');
 const axios = require('axios');
 
 const githubToken = core.getInput('github-token', {required: true})
-const exemptedBots = core.getInput('exempted-bots', {required: true}).split(',').map(input => input.trim());
 const implicitLicenses = core.getInput('implicit-approval-from-licenses', {required: true}).split(',').map(input => input.trim());
 
 // Returns the license that grants implicit CLA if found in the commit message.
@@ -64,7 +63,7 @@ async function run() {
     if (!username) {
       continue;
     }
-    if (username.endsWith('[bot]') && exemptedBots.includes(username.slice(0, -5))) {
+    if (username.endsWith('[bot]')) {
       console.log('- ' + username + ' ✓ (Bot exempted from CLA)');
       commit_authors[i]['signed'] = true;
       continue


### PR DESCRIPTION
Remove `exempted-bots` option as we do not require CLA to be signed by automated tooling