### PR TITLE
Remove `implicit-approval-from-licenses` option 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'The GitHub access token (e.g. secrets.GITHUB_TOKEN) used to create a CLA comment on the pull request (default: {{ github.token }}).'
     default: '${{ github.token }}'
     required: false
-  implicit-approval-from-licenses:
-    description: 'Licences for which an implicit approval of the CLA is assumed.'
-    default: 'Apache-2.0'
-    required: false
 runs:
   using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
as we require all commits to have CLA signed.

However, there are certain repos that were granted legal permission for cherry-picking commits with specific license, those we exclude in the code.