### PR TITLE
feat: exclude weblate bot from CLA check

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const axios = require('axios');
 const githubToken = core.getInput('github-token', {required: true})
+const knownBotAccounts = ['weblate'];
 
 /**
  * A mapping of repositories to their respective licenses.
@@ -65,7 +66,7 @@ function processCLAExceptions(commitAuthors) {
     if (!username) {
       continue;
     }
-    if (username.endsWith('[bot]')) {
+    if (username.endsWith('[bot]') || knownBotAccounts.includes(username)) {
       console.log(`- ${username} ✓ (Bot exempted from CLA)`);
       author.signed = true;
       continue;


### PR DESCRIPTION
As discussed in https://github.com/canonical/has-signed-canonical-cla/pull/61#issuecomment-2783422351 we're using https://weblate.org to manage translations for various Flutter projects in the Ubuntu Desktop team. This service uses a [normal GitHub user account](https://github.com/weblate) (the account name doesn't include `[bot]`) to open automated PRs that sync translations. See https://docs.weblate.org/en/weblate-5.9.2/vcs.html#accessing-repositories-from-hosted-weblate for more details on this. We'd like to exclude those PRs from the CLA check as it is not required for translations.

In existing workflows that still use `v1`, we have explicitly excluded this account from the check, see e.g. [here](https://github.com/canonical/ubuntu-desktop-provision/blob/4b532e0fb8e2816438d9917ee841d0a2e3eadf2c/.github/workflows/pr.yaml#L8).
This PR adds a hardcoded list of known GitHub accounts that are used for automated flows but aren't proper "bot" accounts and excludes those from the check.
