### PR TITLE
fix: prevent crash on merge_group by discovering PRs from head_sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This GitHub Action verifies whether or not the authors of a pull request have si
 
 ```
 name: cla-check
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   cla-check:


### PR DESCRIPTION
Previously the action assumed `github.context.payload.pull_request` existed and accessed `pull_request.commits_url`, causing a crash on events like `merge_group` (which don't include a `pull_request` object). This happens when the action is used by a workflow that is not part of the repository where the `merge_group` event was triggered. See https://github.com/canonical/multipass/actions/runs/16891282907/job/47851417609.

This patch:
- Detects event shape (`pull_request`, `merge_group`, `check_suite`).
- For `merge_group`, uses `merge_group.head_sha` and `octokit.rest.repos.listPullRequestsAssociatedWithCommit`
  to find associated PR(s).
- Uses `octokit.rest.pulls.listCommits` + `paginate` to fetch commits.
- Adds defensive null-checks for commit/author fields.
- Improves logging and failure messages when no PRs can be discovered.
- Parallelizes the fetching of PRs

Fixes #84 