### PR TITLE
fix: compare base and head sha for retrieving commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,32 +173,58 @@ async function run() {
   const {owner, repo} = github.context.repo;
   const payload = github.context.payload;
 
-  // Determine PRs to examine. Support:
-  //  - pull_request event (payload.pull_request)
-  //  - merge_group (payload.merge_group.head_sha) -> map commit -> PRs
-  //  - check_suite (payload.check_suite.pull_requests)
-  let prs = [];
+  let commits = [];
 
   if (payload && payload.pull_request) {
-    prs = [payload.pull_request];
+    const prNumber = payload.pull_request.number;
+    console.log(`Collecting commits for PR #${prNumber}`);
+    commits = await ghRepo.paginate(
+        ghRepo.rest.pulls.listCommits,
+        {owner, repo, pull_number: prNumber, per_page: 100});
   } else if (payload && payload.merge_group && payload.merge_group.head_sha) {
     const headSha = payload.merge_group.head_sha;
-    console.log(
-        `merge_group event detected, attempting to discover PRs for commit ${
-            headSha}`);
-    const resp = await ghRepo.rest.repos.listPullRequestsAssociatedWithCommit(
-        {owner, repo, commit_sha: headSha});
-    prs = resp && resp.data ? resp.data : [];
+
+    let baseSha = payload.merge_group.base_sha || null;
+    if (baseSha) {
+      try {
+        console.log(`Comparing ${baseSha}...${headSha}`);
+        const comp = await ghRepo.rest.repos.compareCommits(
+            {owner, repo, base: baseSha, head: headSha});
+        commits = comp?.data?.commits || [];
+      } catch (err) {
+        core.setFailed(`Failed to compare ${baseSha}...${
+            headSha} for merge_group: ${err?.message ?? err}`);
+        return;
+      }
+    } else {
+      core.setFailed(`No base commit to compare against for head ${headSha}`);
+      return;
+    }
   } else if (
       payload && payload.check_suite &&
       Array.isArray(payload.check_suite.pull_requests) &&
       payload.check_suite.pull_requests.length > 0) {
-    prs = payload.check_suite.pull_requests;
+    const prs = payload.check_suite.pull_requests;
+    const perPr = await Promise.all(prs.map(async pr => {
+      const prNumber = pr.number || pr.pull_request?.number;
+      if (!prNumber) {
+        throw new Error(
+            'check_suite contained a pull_request entry without a number');
+      }
+      return await ghRepo.paginate(
+          ghRepo.rest.pulls.listCommits,
+          {owner, repo, pull_number: prNumber, per_page: 100});
+    }));
+    commits = perPr.flat();
+  } else {
+    core.setFailed(
+        'No pull_request, check_suite.pull_requests, or merge_group.head_sha found in the event payload.');
+    return;
   }
 
-  if (!prs || prs.length === 0) {
+  if (!commits || commits.length === 0) {
     core.setFailed(
-        'No pull request information could be discovered in the event payload.');
+        'No commits could be discovered to run CLA checks against (empty commit list).');
     return;
   }
 
@@ -207,54 +233,31 @@ async function run() {
       `${owner}/${repo}`;
   const repoInLicenseMap = repoFullName in licenseMap;
   var commitAuthors = {};
-  var nCommits = 0;
 
-  // For every PR discovered, list its commits and collect authors.
-  for (const pr of prs) {
-    const commitsPerPr = await Promise.all(prs.map(async pr => {
-      const prNumber = pr.number || (pr.pull_request && pr.pull_request.number);
-      if (!prNumber) {
-        console.log('Skipping an entry without a pull request number');
-        return [];
+  for (const commitObj of commits) {
+    // Check license header for repo-in-licenseMap repos
+    if (commitObj && commitObj.commit && commitObj.commit.message &&
+        repoInLicenseMap) {
+      const goodLicense =
+          hasImplicitLicense(commitObj.commit.message, repoFullName);
+      if (goodLicense) {
+        console.log(`- commit ${commitObj.sha} ✓ (${goodLicense} license)`);
+        continue;
       }
-      console.log(`Collecting commits for PR #${prNumber}`);
-      return await ghRepo.paginate(
-          ghRepo.rest.pulls.listCommits,
-          {owner, repo, pull_number: prNumber, per_page: 100});
-    }));
-
-    const commits = commitsPerPr.flat();
-    nCommits += commits.length;
-
-    for (const commitObj of commits) {
-      // Check if the commit message contains a license header that matches
-      // one of the licenses granting implicit CLA approval
-      if (commitObj && commitObj.commit && commitObj.commit.message &&
-          repoInLicenseMap) {
-        const goodLicense =
-            hasImplicitLicense(commitObj.commit.message, repoFullName);
-        if (goodLicense) {
-          console.log(`- commit ${commitObj.sha} ✓ (${goodLicense} license)`);
-          continue;
-        }
-      }
-
-      const email = commitObj && commitObj.commit && commitObj.commit.author &&
-          commitObj.commit.author.email;
-      if (!email) {
-        core.setFailed(`Commit ${commitObj.sha} has no author email.`);
-        return;
-      }
-
-      const username = (commitObj.author && commitObj.author.login) ?
-          commitObj.author.login :
-          null;
-      commitAuthors[email] =
-          commitAuthors[email] || {username: username, signed: false};
     }
+
+    const email = commitObj?.commit?.author?.email;
+    if (!email) {
+      core.setFailed(`Commit ${commitObj.sha} has no author email.`);
+      return;
+    }
+
+    const username = commitObj?.author?.login ?? null;
+    commitAuthors[email] =
+        commitAuthors[email] || {username: username, signed: false};
   }
 
-  console.log(`Discovered ${nCommits} commits.`);
+  console.log(`Discovered ${commits.length} commits.`);
 
   processCLAExceptions(commitAuthors);
   const claStatus = await checkCLAService(commitAuthors);


### PR DESCRIPTION
Compare between the `head_sha` and `base_sha` when collecting commits in a merge group. Otherwise, use the PR number to collect commits. Then, proceed to analysis list of commits.

For merge queues, the equivalent of `gh api repos/ORG/REPO/compare/base_sha...head_sha --jq '.commits[] | {sha:.sha, email:.commit.author.email, login:(.author.login // null), message:.commit.message}'` is executed.