### PR TITLE
Add required permissions to example usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ on:
 jobs:
   cla-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
- The action recently began failing with a  "Resource not accessible by integration" error when trying to list PR commits. 
- This can be fixed by explicitly granting `contents: read` and `pull-requests: read` permissions to the workflow to restore the ability to check CLA status on branches and forks alike.
- Update the example usage in the README with these permissions